### PR TITLE
Use generators instead of lists and remove extra calls

### DIFF
--- a/hotpdf/helpers/nanoid.py
+++ b/hotpdf/helpers/nanoid.py
@@ -17,7 +17,7 @@ def method(algorithm: Callable[[int], bytearray], alphabet: str, size: int) -> s
     mask = 1
     if alphabet_len > 1:
         mask = (2 << int(log(alphabet_len - 1) / log(2))) - 1
-    step = int(ceil(1.6 * mask * size / alphabet_len))
+    step = ceil(1.6 * mask * size / alphabet_len)
 
     id = ""
     while True:

--- a/hotpdf/hotpdf.py
+++ b/hotpdf/hotpdf.py
@@ -1,4 +1,3 @@
-import gc
 import logging
 import math
 import os
@@ -97,8 +96,8 @@ class HotPdf:
                 parsed_page.build_memory_map()
                 parsed_page.load_memory_map(page=element, drop_duplicate_spans=drop_duplicate_spans)
                 self.pages.append(parsed_page)
+                element.clear()
             root.clear()
-        gc.collect()
 
     def __extract_full_text_span(
         self,


### PR DESCRIPTION
- In memory map, moved everything to use generators instead of lists
- Removed extra calls that are not required, such as int(ceil... etc