### PR TITLE
refactor: unified dev deps, update README.md

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,5 @@ jobs:
         TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
         TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       run: |
-        echo $TWINE_USERNAME
         python -m build
         twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,17 +33,9 @@ jobs:
         python3 -m ruff check
     - name: Run mypy
       run: python -m mypy
-    # - name: Use as an external package
-    #   run: |
-    #     mkdir $HOME/test_external_dir
-    #     cd $HOME/test_external_dir
-    #     python -m venv venv
-    #     source venv/bin/activate
-    #     pip install $GITHUB_WORKSPACE
-    #     python -c "from hotpdf import Hotpdf; print(Hotpdf())"
 
   tests:
-    name: Unit tests
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -65,3 +57,12 @@ jobs:
       - name: Run tests with coverage
         run:
           python -m pytest --cov=hotpdf -n=auto tests/ --cov-fail-under=100
+      - name : Use as external package and run a test
+        run: |
+          mkdir $HOME/test_external_dir
+          cd $HOME/test_external_dir
+          cp $GITHUB_WORKSPACE/tests/ . -r
+          python -m venv venv
+          source venv/bin/activate
+          pip install hotpdf pytest
+          python -m pytest -k "test_full_text"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       run: pip install -e '.[dev]'
     - name: Lint with ruff
       run: |
-        python3 -m ruff
+        python3 -m ruff check
     - name: Run mypy
       run: python -m mypy
     # - name: Use as an external package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
       run: pip install -e '.[dev]'
     - name: Lint with ruff
       run: |
+        pip install --upgrade --force-reinstall ruff
         python3 -m ruff check
     - name: Run mypy
       run: python -m mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,12 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
-        key: linting-packages-${{ hashFiles('**/pyproject.toml') }}-3.11
+        key: dev-${{ hashFiles('**/pyproject.toml') }}-3.11
     - name: Install dependencies
-      run: pip install -e '.[linting,testing]'
+      run: pip install -e '.[dev]'
     - name: Lint with ruff
       run: |
-        pip3 install --upgrade --force-reinstall ruff
-        python3 -m ruff .
+        python3 -m ruff
     - name: Run mypy
       run: python -m mypy
     # - name: Use as an external package
@@ -59,9 +58,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
-          key: testing-packages-${{ hashFiles('**/pyproject.toml') }}-3.11
+          key: dev-${{ hashFiles('**/pyproject.toml') }}-3.11
       - name: Install dependencies
-        run: pip install -e '.[testing]'
+        run: pip install -e '.[dev]'
       - name: Run tests with coverage
         run:
           python -m pytest --cov=hotpdf -n=auto tests/ --cov-fail-under=100

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+# hotpdf
+
 [![Documentation Status](https://readthedocs.org/projects/hotpdf/badge/?version=latest)](https://hotpdf.readthedocs.io/en/latest/?badge=latest)
 [![Release](https://github.com/weareprestatech/hotpdf/actions/workflows/python-publish.yml/badge.svg?branch=main)](https://github.com/weareprestatech/hotpdf/actions/workflows/python-publish.yml)
-
-# hotpdf
 
 This project was started as an internal project @ [Prestatech](http://prestatech.com/) to parse PDF files in a fast and memory efficient way to overcome the difficulties we were having while parsing big PDF files using libraries such as [pdfquery](https://github.com/jcushman/pdfquery).
 
@@ -9,7 +9,8 @@ hotpdf can be used to find and extract text from PDFs.
 Please [read the docs](https://hotpdf.readthedocs.io/en/latest/) to understand how the library can help you!
 
 ## Installation
-The latest version of hotpdf can be installed directly from [PYPI](https://pypi.org/project/hotpdf/) with pip.
+
+The latest version of hotpdf can be installed directly from [PyPI](https://pypi.org/project/hotpdf/) with pip.
 
 ```bash
 pip install hotpdf
@@ -24,7 +25,9 @@ pip install hotpdf
 
 ### Contributing
 
-You should install the [pre-commit](https://github.com/weareprestatech/hotpdf/blob/main/.pre-commit-config.yaml) hooks with `pre-commit install`. This will run the linter, mypy, and a subset of the tests on every commit.
+You should install the [pre-commit](https://github.com/weareprestatech/hotpdf/blob/main/.pre-commit-config.yaml) hooks with `pre-commit install`. This will run the linter, mypy, and ruff formatting before each commit.
+
+Rembember to run `pip install -e '.[dev]'` to install the extra dependencies for development.
 
 For more examples of how to run the full test suite please refer to the [CI workflow](https://github.com/weareprestatech/hotpdf/blob/main/.github/workflows/test.yml).
 
@@ -33,7 +36,7 @@ We strive to keep the test coverage at 100%: if you want your contributions acce
 Some examples of running tests locally:
 
 ```bash
-python3 -m pip install -e '.[testing]'               # install extra deps for testing
+python3 -m pip install -e '.[dev]'               # install extra deps for testing
 python3 -m pytest -n=auto test/                      # run the test suite
 ```
 
@@ -41,9 +44,10 @@ python3 -m pytest -n=auto test/                      # run the test suite
 
 **To view more detailed usage information, please [read the docs](https://hotpdf.readthedocs.io/en/latest/)**
 
-
 Basic usage is as follows:
+
 ```python
+
 from hotpdf import HotPdf
 
 pdf_file_path = "test.pdf"
@@ -79,9 +83,11 @@ spans_in_bbox = hotpdf_document.extract_spans(
    page=0,
 )
 ```
+
 For more granular function level documentation please check the [docs](https://hotpdf.readthedocs.io/en/latest/).
 
 ## License
+
 This project is licensed under the terms of the MIT license.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ keywords = [
 ]
 
 [project.optional-dependencies]
-testing = ["pytest", "pytest-cov", "pytest-xdist"]
-linting = ["pylint", "mypy", "typing-extensions", "pre-commit", "ruff"]
+dev = ["pytest", "pytest-cov", "pytest-xdist", "pylint", "mypy", "typing-extensions", "pre-commit", "ruff"]
 
 [tool.ruff]
 indent-width = 4
@@ -60,6 +59,8 @@ select = [
   "UP039",  # unnecessary-class-parentheses
 ]
 
+fix = true
+fixable = ["ALL"]
 exclude = ["docs"]
 preview = true
 line-length = 150


### PR DESCRIPTION
Unified all dependencies under [dev] section in pyproject.toml.
Now dev environment can be installed using `pip install -e '.[dev]'`
Modified github action and added the step in readme.md

Also added the fix flag to ruff to try and fix automatic linting errors
@krishnasism should we also format the code in the CI with `ruff format`?