### PR TITLE
Remove reference to tests file in prod code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,4 +65,5 @@ jobs:
         run:
           python -m pytest --cov -n=auto tests/ --cov-fail-under=98 --cov-report=
       - name: Upload coverage to coveralls
+        if: github.event_name == 'push'
         uses: coverallsapp/github-action@v2.2.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,6 @@ jobs:
         run: pip install -e '.[dev]'
       - name: Run tests with coverage
         run:
-          python -m pytest --cov=hotpdf -n=auto tests/ --cov-fail-under=98 --cov-report=
+          python -m pytest --cov -n=auto tests/ --cov-fail-under=98 --cov-report=
       - name: Upload coverage to coveralls
         uses: coverallsapp/github-action@v2.2.3

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .vscode/
+
+# MACOS
+.DS_Store

--- a/hotpdf/hotpdf.py
+++ b/hotpdf/hotpdf.py
@@ -1,4 +1,3 @@
-import logging
 import math
 import os
 import warnings
@@ -27,16 +26,11 @@ class HotPdf:
         """
         self.pages: list[MemoryMap] = []
         self.extraction_tolerance: int = extraction_tolerance
-        self.xml_file_path: str
+        self.xml_file_path: Optional[str] = None
 
-    def __del__(self) -> None:
-        try:
-            if "tests/resources/xml" not in self.xml_file_path:
-                os.remove(self.xml_file_path)
-                logging.info("[hotpdf] Deleted")
-        except Exception as e:
-            logging.error("[hotpdf] Unable to delete xml_file")
-            logging.error(str(e))
+    def __delete_xml_file(self) -> None:
+        if self.xml_file_path and os.path.exists(self.xml_file_path):
+            os.remove(self.xml_file_path)
 
     def __check_file_exists(self, pdf_file: str) -> None:
         if not os.path.exists(pdf_file):
@@ -99,6 +93,7 @@ class HotPdf:
                 self.pages.append(parsed_page)
                 element.clear()
             root.clear()
+        self.__delete_xml_file()
 
     def __extract_full_text_span(
         self,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -20,7 +20,7 @@ def mock_hotpdf_bank_file_name():
     return "tests/resources/hotpdf_bank.pdf"
 
 
-def xlm_copy_file_name(xml_file_name: str):
+def xml_copy_file_name(xml_file_name: str):
     shutil.copy(xml_file_name, f"{xml_file_name}_copy.xml")
     return f"{xml_file_name}_copy.xml"
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -107,7 +107,7 @@ def test_sparse_matrix_iterator():
 def test_duplicate_spans_not_removed(mock_hotpdf_bank_file_name):
     hot_pdf_object = HotPdf()
     hot_pdf_object_with_dup_span = HotPdf()
-    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xml_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
         hot_pdf_object_with_dup_span.load(mock_hotpdf_bank_file_name, drop_duplicate_spans=False)
     with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
         hot_pdf_object.load(mock_hotpdf_bank_file_name)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -109,7 +109,7 @@ def test_duplicate_spans_not_removed(mock_hotpdf_bank_file_name):
     hot_pdf_object_with_dup_span = HotPdf()
     with patch("hotpdf.processor.generate_xml_file", return_value=xml_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
         hot_pdf_object_with_dup_span.load(mock_hotpdf_bank_file_name, drop_duplicate_spans=False)
-    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xml_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
         hot_pdf_object.load(mock_hotpdf_bank_file_name)
 
     assert len(hot_pdf_object.pages[0].span_map) < len(hot_pdf_object_with_dup_span.pages[0].span_map)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +18,11 @@ def valid_file_name():
 @pytest.fixture
 def mock_hotpdf_bank_file_name():
     return "tests/resources/hotpdf_bank.pdf"
+
+
+def xlm_copy_file_name(xml_file_name: str):
+    shutil.copy(xml_file_name, f"{xml_file_name}_copy.xml")
+    return f"{xml_file_name}_copy.xml"
 
 
 def test_load_file(valid_file_name):
@@ -98,24 +104,25 @@ def test_sparse_matrix_iterator():
     assert non_empty_values == expected_result
 
 
-@patch("hotpdf.processor.generate_xml_file", return_value="tests/resources/xml/hotpdf_bank_dup_span.xml", autospec=True)
-def test_duplicate_spans_not_removed(_, mock_hotpdf_bank_file_name):
+def test_duplicate_spans_not_removed(mock_hotpdf_bank_file_name):
     hot_pdf_object = HotPdf()
     hot_pdf_object_with_dup_span = HotPdf()
-    hot_pdf_object_with_dup_span.load(mock_hotpdf_bank_file_name, drop_duplicate_spans=False)
-    hot_pdf_object.load(mock_hotpdf_bank_file_name)
+    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
+        hot_pdf_object_with_dup_span.load(mock_hotpdf_bank_file_name, drop_duplicate_spans=False)
+    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_dup_span.xml")):
+        hot_pdf_object.load(mock_hotpdf_bank_file_name)
 
     assert len(hot_pdf_object.pages[0].span_map) < len(hot_pdf_object_with_dup_span.pages[0].span_map)
 
 
 def test_load_negative_coordinates(mock_hotpdf_bank_file_name):
     QUERY = "HOTPDF BANK"
-    with patch("hotpdf.processor.generate_xml_file", return_value="tests/resources/xml/hotpdf_bank_negative_coords.xml"):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_negative_coords.xml")):
         hot_pdf_object = HotPdf()
         hot_pdf_object.load(mock_hotpdf_bank_file_name)
         assert not hot_pdf_object.find_text(QUERY)[0], "Expected string to be empty"
     # For sanity: The following file is same as above, except the coords are normal
-    with patch("hotpdf.processor.generate_xml_file", return_value="tests/resources/xml/hotpdf_bank_normal_coords.xml"):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_normal_coords.xml")):
         hot_pdf_object_normal = HotPdf()
         hot_pdf_object_normal.load(mock_hotpdf_bank_file_name)
         assert hot_pdf_object_normal.find_text(QUERY)[0], "Expected string to be not empty"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -117,7 +117,7 @@ def test_duplicate_spans_not_removed(mock_hotpdf_bank_file_name):
 
 def test_load_negative_coordinates(mock_hotpdf_bank_file_name):
     QUERY = "HOTPDF BANK"
-    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_negative_coords.xml")):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xml_copy_file_name("tests/resources/xml/hotpdf_bank_negative_coords.xml")):
         hot_pdf_object = HotPdf()
         hot_pdf_object.load(mock_hotpdf_bank_file_name)
         assert not hot_pdf_object.find_text(QUERY)[0], "Expected string to be empty"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -122,7 +122,7 @@ def test_load_negative_coordinates(mock_hotpdf_bank_file_name):
         hot_pdf_object.load(mock_hotpdf_bank_file_name)
         assert not hot_pdf_object.find_text(QUERY)[0], "Expected string to be empty"
     # For sanity: The following file is same as above, except the coords are normal
-    with patch("hotpdf.processor.generate_xml_file", return_value=xlm_copy_file_name("tests/resources/xml/hotpdf_bank_normal_coords.xml")):
+    with patch("hotpdf.processor.generate_xml_file", return_value=xml_copy_file_name("tests/resources/xml/hotpdf_bank_normal_coords.xml")):
         hot_pdf_object_normal = HotPdf()
         hot_pdf_object_normal.load(mock_hotpdf_bank_file_name)
         assert hot_pdf_object_normal.find_text(QUERY)[0], "Expected string to be not empty"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -224,18 +224,7 @@ def test_get_spans(valid_file_name):
 
     # Test Non Existent Word
     occurences = hot_pdf_object.find_text(NON_EXISTENT_WORD)
-    for _, page_num in enumerate(occurences):
-        occurences_by_page = occurences[page_num]
-        for occurence_by_page in occurences_by_page:
-            element_dimension = get_element_dimension(occurence_by_page)
-            full_spans_in_bbox = hot_pdf_object.extract_spans(
-                x0=element_dimension.x0,
-                y0=element_dimension.y0,
-                x1=element_dimension.x1,
-                y1=element_dimension.y1,
-            )
-            # Assert empty list returned
-            assert full_spans_in_bbox == []
+    assert occurences == {0: []}
 
 
 @pytest.mark.parametrize("first_page, last_page", [(1, 1), (1, 2)])


### PR DESCRIPTION
- Delete the xml after the loading is done
- Fixed coverage on tests folder
- Removed test file check on prod code

@krishnasism what do you think? Just an idea, but I do think we shouldn't have references to tests files in the prod code.
This may be a solution :)