### PR TITLE
features: Multiple HotPdf object merge, Prevent overlapping chars from overwriting each other, enable pdfminer caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ with open(pdf_file_path, "rb") as f:
 from hotpdf.encodings.types import EncodingTypes
 hotpdf_cid_removal_object = HotPdf(f, cid_overwrite_charset=EncodingTypes.LATIN)
 
+# You can also merge multiple HotPdf objects to get one single HotPdf object
+merged_hotpdf_object = HotPdf.merge_multiple(hotpdfs=[hotpdf1, hotpdf2])
+
 # Get number of pages
 print(len(hotpdf_document.pages))
 

--- a/docs/source/generated/hotpdf.hotpdf.HotPdf.rst
+++ b/docs/source/generated/hotpdf.hotpdf.HotPdf.rst
@@ -20,3 +20,4 @@
       ~HotPdf.extract_text
       ~HotPdf.find_text
       ~HotPdf.load
+      ~HotPdf.merge_multiple

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -41,6 +41,15 @@ Alternatively, to load a file, you can also defer loading from the constructor a
     with open(pdf_file_path, "rb") as f:
         hotpdf_document_2.load(f)
 
+You can also merge multiple HotPdf objects to get one single HotPdf object!
+
+.. code-block:: python
+
+    merged_hotpdf_object = HotPdf.merge_multiple(hotpdfs=[
+        hotpdf_document,
+        hotpdf_document2,
+    ])
+
 
 Sometimes pdfminer.six will not replace (cid:x) values with their corresponding Unicode values.
 In that case, send the charset Encoder.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -42,6 +42,18 @@ Alternatively you can defer loading, and use the `.load()` function instead. The
 
 .. autofunction:: hotpdf.HotPdf.load
 
+You can also merge multiple HotPdf objects to get one single HotPdf object!
+
+.. code-block:: python
+
+    merged_hotpdf_object = HotPdf.merge_multiple(hotpdfs=[
+        hotpdf_document,
+        hotpdf_document2,
+    ])
+
+
+.. autofunction:: hotpdf.HotPdf.merge_multiple
+
 Sometimes pdfminer.six will not replace (cid:x) values with their corresponding Unicode values.
 In that case, send the charset Encoder.
 

--- a/hotpdf/exceptions/custom_exceptions.py
+++ b/hotpdf/exceptions/custom_exceptions.py
@@ -1,2 +1,6 @@
 class DecoderNotInitalised(Exception):
     pass
+
+
+class HotPdfIsNoneError(Exception):
+    pass

--- a/hotpdf/hotpdf.py
+++ b/hotpdf/hotpdf.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 
 from hotpdf import processor
 from hotpdf.encodings.types import EncodingTypes
+from hotpdf.exceptions.custom_exceptions import HotPdfIsNoneError
 from hotpdf.memory_map import MemoryMap
 from hotpdf.utils import filter_adjacent_coords, intersect
 
@@ -50,6 +51,8 @@ class HotPdf:
         self.extraction_tolerance: int = extraction_tolerance
         if hotpdfs:
             for _hotpdf in hotpdfs:
+                if not _hotpdf:
+                    raise HotPdfIsNoneError("HotPdf object cannot be None")
                 self.pages.extend(_hotpdf.pages)
             return
         if pdf_file:

--- a/hotpdf/hotpdf.py
+++ b/hotpdf/hotpdf.py
@@ -23,6 +23,7 @@ class HotPdf:
         laparams: Optional[dict[str, Union[float, bool]]] = None,
         include_annotation_spaces: bool = False,
         cid_overwrite_charset: Optional[EncodingTypes] = None,
+        hotpdfs: Optional[list["HotPdf"]] = None,
     ) -> None:
         """Initialize the HotPdf class.
 
@@ -37,7 +38,8 @@ class HotPdf:
             include_annotation_spaces (bool, optional): Add annotation spaces to the memory map.
             cid_overwrite_charset (EncodingTypes, optional): Overwrite encode charset for (cid:x) values
                 that haven't been converted. Default None, will return cid values as is without conversion
-
+            hotpdfs (list[HotPdf], optional): List of HotPdf objects that will be combined
+                to form one single HotPdf object. All other params will be ignored in this case.
         Raises:
             ValueError: If the page range is invalid.
             FileNotFoundError: If the file is not found.
@@ -46,6 +48,10 @@ class HotPdf:
         """
         self.pages: list[MemoryMap] = []
         self.extraction_tolerance: int = extraction_tolerance
+        if hotpdfs:
+            for _hotpdf in hotpdfs:
+                self.pages.extend(_hotpdf.pages)
+            return
         if pdf_file:
             self.load(
                 pdf_file,

--- a/hotpdf/hotpdf.py
+++ b/hotpdf/hotpdf.py
@@ -24,7 +24,6 @@ class HotPdf:
         laparams: Optional[dict[str, Union[float, bool]]] = None,
         include_annotation_spaces: bool = False,
         cid_overwrite_charset: Optional[EncodingTypes] = None,
-        hotpdfs: Optional[list["HotPdf"]] = None,
     ) -> None:
         """Initialize the HotPdf class.
 
@@ -39,8 +38,6 @@ class HotPdf:
             include_annotation_spaces (bool, optional): Add annotation spaces to the memory map.
             cid_overwrite_charset (EncodingTypes, optional): Overwrite encode charset for (cid:x) values
                 that haven't been converted. Default None, will return cid values as is without conversion
-            hotpdfs (list[HotPdf], optional): List of HotPdf objects that will be combined
-                to form one single HotPdf object. All other params will be ignored in this case.
         Raises:
             ValueError: If the page range is invalid.
             FileNotFoundError: If the file is not found.
@@ -49,12 +46,6 @@ class HotPdf:
         """
         self.pages: list[MemoryMap] = []
         self.extraction_tolerance: int = extraction_tolerance
-        if hotpdfs:
-            for _hotpdf in hotpdfs:
-                if not _hotpdf:
-                    raise HotPdfIsNoneError("HotPdf object cannot be None")
-                self.pages.extend(_hotpdf.pages)
-            return
         if pdf_file:
             self.load(
                 pdf_file,
@@ -89,6 +80,28 @@ class HotPdf:
         if type(pdf_file) is str:
             self.__check_file_exists(pdf_file)
         self.__check_page_range(page_numbers)
+
+    @staticmethod
+    def merge_multiple(
+        hotpdfs: list["HotPdf"],
+    ) -> "HotPdf":
+        """Merge multiple HotPdf objects and return a single HotPdf object consisting of all pages
+
+        Args:
+            hotpdfs (list[HotPdf]): List of HotPdf objects that will be combined
+                to form one single HotPdf object. All other params will be ignored in this case.
+        Raises:
+            HotPdfIsNoneError: If any of the HotPdf objects in the hotpdfs list is None
+
+        Returns:
+            HotPdf: Merged HotPdf object
+        """
+        if any(_hotpdf is None for _hotpdf in hotpdfs):
+            raise HotPdfIsNoneError("HotPdf object cannot be None")
+        merged_hotpdf = HotPdf()
+        for _hotpdf in hotpdfs:
+            merged_hotpdf.pages.extend(_hotpdf.pages)
+        return merged_hotpdf
 
     def load(
         self,

--- a/hotpdf/memory_map.py
+++ b/hotpdf/memory_map.py
@@ -1,4 +1,5 @@
 import math
+from collections import defaultdict
 from collections.abc import Generator
 from typing import Optional, Union
 
@@ -74,6 +75,7 @@ class MemoryMap:
         char_hot_characters: list[HotCharacter] = []
         char_encoder = Decoder(cid_overwrite_charset)
         page_components: Generator[Union[LTTextLine, LTChar], None, None] = self.__get_page_spans(page)
+        line_shift: defaultdict[int, int] = defaultdict(int)
         for component in page_components:
             span_id = generate_nano_id(size=10)
             prev_char_inserted = False
@@ -130,18 +132,25 @@ class MemoryMap:
                     )
                     prev_char_inserted = char_c != " "
         # Insert into Trie and Span Maps
-        average_text_distance: int = 0
+        last_inserted_x_y: tuple[int, int] = (-1, -1)
         for i in range(len(char_hot_characters)):
             _current_character: HotCharacter = char_hot_characters[i]
             # Determine if annotation spaces should be added
             if include_annotation_spaces and i > 0 and i < len(char_hot_characters) - 1:
                 prev_char: HotCharacter = char_hot_characters[i - 1]
                 next_char: HotCharacter = char_hot_characters[i + 1]
-                if _current_character.is_anno and (not (next_char.x - prev_char.x_end) >= average_text_distance):
+                if _current_character.is_anno and (not (next_char.x - prev_char.x_end) >= 5):
                     continue
-                elif not (next_char.is_anno or prev_char.is_anno):
-                    average_text_distance += next_char.x - prev_char.x_end
-                    average_text_distance //= 2
+
+            # Prevent characters from overlapping
+            if (last_inserted_x_y[0] > 0 and last_inserted_x_y[1] > 0) and (
+                _current_character.x == last_inserted_x_y[0] and _current_character.y == last_inserted_x_y[1]
+            ):
+                line_shift[_current_character.y] += 1
+            last_inserted_x_y = (_current_character.x, _current_character.y)
+            _current_character.x += line_shift[_current_character.y]
+            _current_character.x_end += line_shift[_current_character.y]
+
             self.__insert_hotcharacter_to_memory(_current_character)
         self.width = math.ceil(page.width)
         self.height = math.ceil(page.height)

--- a/hotpdf/memory_map.py
+++ b/hotpdf/memory_map.py
@@ -57,6 +57,20 @@ class MemoryMap:
             elif isinstance(obj, (LTFigure)):
                 yield from self.__extract_from_ltfigure(obj)
 
+    def __get_right_shifted_hot_character(self, hot_character: HotCharacter, shift: int) -> HotCharacter:
+        """Shift a hotcharacter on the x-coordinate
+
+        Args:
+            hot_character (HotCharacter): HotCharacter object to be shifted
+            shift (int): shift offset on the x-coordinate
+
+        Returns:
+            HotCharacter: HotCharacter object with new coords
+        """
+        hot_character.x += shift
+        hot_character.x_end += shift
+        return hot_character
+
     def load_memory_map(
         self,
         page: LTPage,
@@ -148,8 +162,9 @@ class MemoryMap:
             ):
                 line_shift[_current_character.y] += 1
             last_inserted_x_y = (_current_character.x, _current_character.y)
-            _current_character.x += line_shift[_current_character.y]
-            _current_character.x_end += line_shift[_current_character.y]
+            _current_character = self.__get_right_shifted_hot_character(
+                _current_character, line_shift[_current_character.y]
+            )
 
             self.__insert_hotcharacter_to_memory(_current_character)
         self.width = math.ceil(page.width)

--- a/hotpdf/processor.py
+++ b/hotpdf/processor.py
@@ -42,7 +42,7 @@ def __process(
     laparams_obj = __make_custom_laparams_object(laparams)
 
     hl_page_layouts = extract_pages(
-        source, password=password, page_numbers=page_numbers, caching=False, laparams=laparams_obj
+        source, password=password, page_numbers=page_numbers, caching=True, laparams=laparams_obj
     )
     for page_layout in hl_page_layouts:
         parsed_page: MemoryMap = MemoryMap()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,0 @@
-from hotpdf import HotPdf
-from hotpdf.utils import to_text
-
-pdf = HotPdf("/Users/smartlandindteammachine/Downloads/6663e89b-c10d-4537-9b66-fabead71e959.pdf")
-print(pdf.extract_page_text(0))
-
-pdf = HotPdf("/Users/smartlandindteammachine/Downloads/0168 UNICREDIT TRIMESTRALE 01.2019 - 03.2019 (1).pdf")
-print(to_text(pdf.find_text("Saldo", take_span=True)[0][0]))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -474,7 +474,7 @@ def test_invalid_decoder(valid_file_name):
 
 
 def test_multi_load(valid_file_name, multiple_pages_file_name):
-    big_pdf = HotPdf(
+    big_pdf = HotPdf.merge_multiple(
         hotpdfs=[HotPdf(valid_file_name), HotPdf(multiple_pages_file_name, include_annotation_spaces=True)]
     )
     assert "HOTPDF" in big_pdf.extract_page_text(page=0)
@@ -483,4 +483,4 @@ def test_multi_load(valid_file_name, multiple_pages_file_name):
 
 def test_multi_load_none(multiple_pages_file_name):
     with pytest.raises(HotPdfIsNoneError, match="HotPdf object cannot be None"):
-        _ = HotPdf(hotpdfs=[None, HotPdf(multiple_pages_file_name, include_annotation_spaces=True)])
+        _ = HotPdf.merge_multiple(hotpdfs=[None, HotPdf(multiple_pages_file_name, include_annotation_spaces=True)])

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -436,11 +436,9 @@ def test_include_annotation_spaces_flag_sanity_check(valid_file_name):
     assert len(page_text) > 500
 
 
-@pytest.mark.skip(reason="Test is not implemented properly. Need to rewrite.")
-def test_include_annotation_spaces_flag_(valid_file_name):
-    hotpdf_object = HotPdf(valid_file_name, include_annotation_spaces=True)
-    page_text = hotpdf_object.extract_page_text(0)
-    assert len(page_text) > 500
+def test_include_annotation_spaces_flag(multiple_pages_file_name):
+    hotpdf_obj = HotPdf(multiple_pages_file_name, include_annotation_spaces=True)
+    assert "THE HOLY BIBLE" in hotpdf_obj.extract_page_text(page=0)
 
 
 @pytest.mark.skip(reason="Test this internally.")
@@ -470,6 +468,8 @@ def test_invalid_decoder(valid_file_name):
 
 
 def test_multi_load(valid_file_name, multiple_pages_file_name):
-    big_pdf = HotPdf(hotpdfs=[HotPdf(valid_file_name), HotPdf(multiple_pages_file_name)])
+    big_pdf = HotPdf(
+        hotpdfs=[HotPdf(valid_file_name), HotPdf(multiple_pages_file_name, include_annotation_spaces=True)]
+    )
     assert "HOTPDF" in big_pdf.extract_page_text(page=0)
-    assert "BIBLE" in big_pdf.extract_page_text(page=1)
+    assert "THE HOLY BIBLE" in big_pdf.extract_page_text(page=1)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -439,6 +439,12 @@ def test_include_annotation_spaces_flag_sanity_check(valid_file_name):
 def test_include_annotation_spaces_flag(multiple_pages_file_name):
     hotpdf_obj = HotPdf(multiple_pages_file_name, include_annotation_spaces=True)
     assert "THE HOLY BIBLE" in hotpdf_obj.extract_page_text(page=0)
+    assert "THEHOLYBIBLE" not in hotpdf_obj.extract_page_text(page=0)
+
+    # Inverse
+    hotpdf_obj_no_space = HotPdf(multiple_pages_file_name)
+    assert "THE HOLY BIBLE" not in hotpdf_obj_no_space.extract_page_text(page=0)
+    assert "THEHOLYBIBLE" in hotpdf_obj_no_space.extract_page_text(page=0)
 
 
 @pytest.mark.skip(reason="Test this internally.")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -467,3 +467,9 @@ def test_invalid_decoder(valid_file_name):
 
     with pytest.raises(DecoderNotInitalised, match="Decoder not initialised"):
         _ = HotPdf(valid_file_name, cid_overwrite_charset=EncodingTypes.BATIN)
+
+
+def test_multi_load(valid_file_name, multiple_pages_file_name):
+    big_pdf = HotPdf(hotpdfs=[HotPdf(valid_file_name), HotPdf(multiple_pages_file_name)])
+    assert "HOTPDF" in big_pdf.extract_page_text(page=0)
+    assert "BIBLE" in big_pdf.extract_page_text(page=1)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -9,7 +9,7 @@ from pdfminer.pdfparser import PDFSyntaxError
 from hotpdf import HotPdf
 from hotpdf.data.classes import ElementDimension
 from hotpdf.encodings.types import EncodingTypes
-from hotpdf.exceptions.custom_exceptions import DecoderNotInitalised
+from hotpdf.exceptions.custom_exceptions import DecoderNotInitalised, HotPdfIsNoneError
 from hotpdf.memory_map import MemoryMap
 from hotpdf.utils import get_element_dimension
 
@@ -479,3 +479,8 @@ def test_multi_load(valid_file_name, multiple_pages_file_name):
     )
     assert "HOTPDF" in big_pdf.extract_page_text(page=0)
     assert "THE HOLY BIBLE" in big_pdf.extract_page_text(page=1)
+
+
+def test_multi_load_none(multiple_pages_file_name):
+    with pytest.raises(HotPdfIsNoneError, match="HotPdf object cannot be None"):
+        _ = HotPdf(hotpdfs=[None, HotPdf(multiple_pages_file_name, include_annotation_spaces=True)])


### PR DESCRIPTION
- Added merged HotPdf object loading. This will help us do multiprocessed loads from wrapper.

- Added check to prevent chars from getting overwritten by chars of same x-coords. In this case, we do a right shift after each overlapping char on the same line (y-coord). Fixes issue: https://github.com/weareprestatech/hotpdf/issues/116

- Set caching=True for pdfminer since it has some significant performance improvement (70s -> 50s) for the Bible file.