### PR TITLE
feat: Add 3.12 and 3.13 support

### DIFF
--- a/.github/workflows/build-badge.yml
+++ b/.github/workflows/build-badge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     needs: linter
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       Python3_ROOT_DIR:
     name: Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
 name="hotpdf"
-version="0.5.2"
+version="0.5.3"
 authors = [
   {name = "Krishnasis Mandal", email = "krishnasis@hotmail.com"}]
 maintainers = [
@@ -18,6 +18,8 @@ license = {file = "LICENSE"}
 requires-python = ">=3.9"
 classifiers = [
   "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.9",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -27,7 +27,7 @@ def perform_memory_test(file_name, expected_peak_memory):
 
 
 def test_speed_benchmark_multiple_pages(multiple_pages_file_name):
-    perform_speed_test(multiple_pages_file_name, 3.5)
+    perform_speed_test(multiple_pages_file_name, 4.5)
 
 
 def test_memory_benchmark_multiple_pages(multiple_pages_file_name):
@@ -35,7 +35,7 @@ def test_memory_benchmark_multiple_pages(multiple_pages_file_name):
 
 
 def test_speed_luca_mock(mock_hotpdf_bank_file_name):
-    perform_speed_test(mock_hotpdf_bank_file_name, 3.5)
+    perform_speed_test(mock_hotpdf_bank_file_name, 4.5)
 
 
 def test_memory_luca_mock(mock_hotpdf_bank_file_name):
@@ -43,7 +43,7 @@ def test_memory_luca_mock(mock_hotpdf_bank_file_name):
 
 
 def test_speed_default_file(valid_file_name):
-    perform_speed_test(valid_file_name, 3.5)
+    perform_speed_test(valid_file_name, 4.5)
 
 
 @pytest.mark.skip(reason="Need to perform benchmarks first")


### PR DESCRIPTION
- Updated classifiers in pyproject.toml to include support for Python 3.12 and 3.13
- Updated tests to verify that  the lib works as expected on these versions

Note: 3.12 and 3.13 takes a bit longer to run inside the Github Actions worker