### PR TITLE
build: derive version from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,8 @@ jobs:
       url: https://pypi.org/p/hotpdf
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,9 @@ jobs:
         run: pip install -e '.[dev]'
       - name: Run tests
         run:
-          python -m pytest --cov-fail-under=96 -n=auto --cov=hotpdf --cov-report term-missing
+          python -m pytest --cov-fail-under=96 -n=auto --cov=hotpdf --cov-report term-missing --cov-report xml
       - name: Upload coverage to coveralls
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.python-version == '3.11'
         uses: coverallsapp/github-action@v2.2.3
+        with:
+          file: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
 name="hotpdf"
-version="0.5.3"
+dynamic = ["version"]
 authors = [
   {name = "Krishnasis Mandal", email = "krishnasis@hotmail.com"}]
 maintainers = [
@@ -44,6 +44,8 @@ keywords = [
 dependencies = [
     "pdfminer.six>=20231228",
 ]
+
+[tool.setuptools_scm]
 
 [tool.setuptools]
 include-package-data = false


### PR DESCRIPTION
Replace hardcoded version= with setuptools-scm so the package version comes
from the release tag at build time.